### PR TITLE
Remove nbconvert-core from otter-grader-base dependencies

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 23f67966cb251c0fcdaeeb95a242bdc9fd76cf71c9cdb7e75ba6da763cd97dd7
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -47,7 +47,6 @@ outputs:
         - google-api-python-client
         - google-auth-oauthlib
         - six
-        - nbconvert-core
         - astunparse
         - ipylab
         - ipywidgets


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* ~Reset the build number to `0` (if the version changed)~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.
